### PR TITLE
citrus: rootdir: remove ugly implementation

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -59,9 +59,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     Snap
 
-# Copy fstab to ramdisk
-PRODUCT_COPY_FILES += \
-    $(LOCAL_PATH)/rootdir/etc/fstab.qcom:$(TARGET_COPY_OUT_RAMDISK)/fstab.qcom    
+# Ramdisk
+PRODUCT_PACKAGES += \
+    fstab.qcom  
     
 # fastbootd
 PRODUCT_PACKAGES += \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,1 +1,9 @@
 LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE       := fstab.qcom
+LOCAL_MODULE_TAGS  := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES    := etc/fstab.qcom
+LOCAL_MODULE_PATH  := $(TARGET_OUT_VENDOR_ETC)
+include $(BUILD_PREBUILT)


### PR DESCRIPTION
Copying files like that isn't good, so let's fix it